### PR TITLE
fix:修复radio-group传入circle不展示小圆圈的问题

### DIFF
--- a/packages/fighting-design/radio-group/src/radio-group.ts
+++ b/packages/fighting-design/radio-group/src/radio-group.ts
@@ -27,6 +27,10 @@ export const Props = {
     type: Boolean,
     default: (): boolean => false
   },
+  circle:{
+    type: Boolean,
+    default: (): boolean => false
+  },
   size: {
     type: String as PropType<RadioGroupSizeType>,
     default: (): RadioGroupSizeType => 'middle',

--- a/packages/fighting-design/radio/src/radio.vue
+++ b/packages/fighting-design/radio/src/radio.vue
@@ -100,7 +100,7 @@
       :name="name"
       @change="handleChange"
     />
-    <span v-if="!radioGroup?.border" class="f-radio-circle" />
+    <span v-if="!radioGroup?.border || radioGroup?.circle" class="f-radio-circle" />
     <span class="f-radio-text">
       <slot>{{ label }}</slot>
     </span>


### PR DESCRIPTION
radio-group少传递了个入参导致circle属性不生效

修改前：
![image](https://user-images.githubusercontent.com/50941611/195382543-06cead34-ada6-48de-a9a0-22f8149e0df3.png)

修改后：
![image](https://user-images.githubusercontent.com/50941611/195382611-91b1ad99-3fa0-45bf-8bc4-abfdf2fa0dfc.png)
