### PR TITLE
fix: 修复Loading组件font-color问题，新增icon-color属性

### DIFF
--- a/docs/docs/components/loading.md
+++ b/docs/docs/components/loading.md
@@ -38,7 +38,7 @@
 
 ## 自定义文案
 
-`text` 和 `icon` 属性可以自定义展示的 `icon` 和说明文字
+`text` 和 `icon` 属性可以自定义说明文字和展示的 `icon` 
 
 <f-button type="primary" @click="onclick2">玩命加载</f-button>
 <f-loading :show="loading2" text="玩命加载中……" icon="f-icon-loading6" />
@@ -76,6 +76,7 @@
 | `text`       | 说明文字         | string  | ——     | ——     |
 | `icon`       | loading 的 icon  | string  | ——     | ——     |
 | `font-color` | 说明文字颜色     | string  | ——     | ——     |
+| `icon-color` | loading 的 icon 颜色     | string  | ——     | ——     |
 | `font-size`  | 说明文字大小     | string  | ——     | ——     |
 | `background` | 遮罩层背景色     | string  | ——     | ——     |
 | `opacity`    | 遮罩层透明度     | number  | ——     | ——     |
@@ -96,6 +97,10 @@ import type { LoadingInstance, LoadingPropsType } from 'fighting-design'
 
 <a href="https://github.com/yn22638" target="_blank">
   <f-avatar round src="https://avatars.githubusercontent.com/u/48940123?v=4" />
+</a>
+
+<a href="https://github.com/Alphatrionty" target="_blank">
+  <f-avatar round src="https://avatars.githubusercontent.com/u/57850101?v=4" />
 </a>
 
 <script setup>

--- a/packages/fighting-design/loading/src/loading.ts
+++ b/packages/fighting-design/loading/src/loading.ts
@@ -21,6 +21,10 @@ export const Props = {
     type: String,
     default: (): string => ''
   },
+  iconColor: {
+    type: String,
+    default: (): string => ''
+  },
   fontSize: {
     type: String,
     default: (): string => ''

--- a/packages/fighting-design/loading/src/loading.vue
+++ b/packages/fighting-design/loading/src/loading.vue
@@ -13,20 +13,19 @@
   }
 
   const styleList: ComputedRef<CSSProperties> = computed((): CSSProperties => {
-    const { background, opacity, fontColor } = prop
+    const { background, opacity } = prop
 
     return {
       background,
       opacity,
-      color: fontColor
     } as const
   })
 </script>
 
 <template>
   <div v-if="show" class="f-loading" :style="styleList" @click="handleClick">
-    <f-icon :icon="icon || 'f-icon-loading'" class="f-loading-animation" />
-    <span class="f-loading-title" :style="{ fontSize }">
+    <f-icon :icon="icon || 'f-icon-loading'" class="f-loading-animation" :color="iconColor" />
+    <span class="f-loading-title" :style="{ fontSize, color: fontColor }">
       {{ text || ' 玩命加载中...' }}
     </span>
   </div>

--- a/packages/fighting-theme/src/loading.scss
+++ b/packages/fighting-theme/src/loading.scss
@@ -23,7 +23,6 @@
   }
 
   .f-loading-title {
-    color: $primary;
     font-size: 15px;
   }
 


### PR DESCRIPTION
loading.scss中给.f-loading-title配置了color: $primary;导致设置font-color时，改变了icon的颜色，未改变文字颜色