### PR TITLE
fix:修复vitepress造成的样式问题

### DIFF
--- a/packages/fighting-theme/src/calendar.scss
+++ b/packages/fighting-theme/src/calendar.scss
@@ -167,6 +167,7 @@
     .f-calendar__week {
       border-bottom: 1px solid var(--f-calendar-border-color, var(--f-design-color-border-1));
       border-top: 1px solid var(--f-calendar-border-color, var(--f-design-color-border-1));
+      margin: 0;
 
       .f-calendar__week-li {
         border-right: 1px solid var(--f-calendar-border-color, var(--f-design-color-border-1));
@@ -174,6 +175,7 @@
     }
 
     .f-calendar__day {
+      margin: 0;
       .f-calendar__day-li {
         border-right: 1px solid var(--f-calendar-border-color, var(--f-design-color-border-1));
         border-bottom: 1px solid var(--f-calendar-border-color, var(--f-design-color-border-1));


### PR DESCRIPTION
问题：在文档中我发现有一个边框问题，通过把代码拉下来调试之后发现这是由于 vitepress 默认样式导致的一个问题
解决：给组件增加了一个默认的margin
![image](https://user-images.githubusercontent.com/87807886/209912551-536b31e7-dc1b-4f2d-8770-911504762a8f.png)
![image](https://user-images.githubusercontent.com/87807886/209912976-02619fac-4b3e-4b61-b488-ce201ac6b08a.png)

