### PR TITLE
优化倒计时组件文档以及样式

### DIFF
--- a/docs/components/count-down.md
+++ b/docs/components/count-down.md
@@ -12,7 +12,7 @@
 ::: demo
 
 <template #source>
-<f-count-down :time="timeStamp" format="DD : HH : mm: ss " :finish="handelFinish" />
+<f-count-down :time="timeStamp" format="DD : HH : mm: ss " :on-finish="handelFinish" />
 </template>
 
 ```vue

--- a/packages/fighting-theme/src/count-down.scss
+++ b/packages/fighting-theme/src/count-down.scss
@@ -1,14 +1,9 @@
 .f-count-down {
-  --count-down-font-size: 18px;
-  --count-down-font-color: #1d1d1f;
-}
-
-.f-count-down {
   display: inline-block;
   margin: 5px;
 
   .f-count-down__text {
-    color: var(--count-down-font-color);
-    font-size: var(--count-down-font-size);
+    color: var(--count-down-font-color, 18px);
+    font-size: var(--count-down-font-size, 'inherit');
   }
 }


### PR DESCRIPTION
1. 文档错误，回调方法编写错误
2. 样式问题导致黑色主题下字颜仍为黑的问题修复