### PR TITLE
refactor: 元素监听大小-vue hooks改为原生

### DIFF
--- a/packages/fighting-design/ellipsis/src/ellipsis.vue
+++ b/packages/fighting-design/ellipsis/src/ellipsis.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
   import { Props } from './props'
   import { useList } from '../../_hooks'
-  import { useSlots, ref } from 'vue'
-  import { useResizeObserver } from '@vueuse/core'
+  import { useSlots, ref, onMounted } from 'vue'
   import { debounce } from '../../_utils'
 
   defineOptions({ name: 'FEllipsis' })
@@ -27,12 +26,14 @@
   }
 
   // 监听元素宽度，重新计算是否需要显示tooltip
-  useResizeObserver(
-    fEllipsisRef,
-    debounce(() => {
-      judgeEllipsis()
-    })
-  )
+  onMounted(() => {
+    const resizeObserver = new ResizeObserver(
+      debounce(() => {
+        judgeEllipsis()
+      })
+    )
+    resizeObserver.observe(fEllipsisRef.value as Element)
+  })
 
   /** toggle expand */
   const handleClick = (): void => {

--- a/start/src/App.vue
+++ b/start/src/App.vue
@@ -15,7 +15,7 @@
     永远不改变，拥抱过的美丽都再也不破碎
   </f-ellipsis>
   <h4>3、max-width: 最大宽度，不设置默认宽度auto</h4>
-  <f-ellipsis :max-width="300" :line-clamp="2">
+  <f-ellipsis :line-clamp="1">
     七岁的那一年抓住那只蝉以为能抓住夏天，十七岁的那年吻过她的脸就以为和她能永远，有没有那么一种永远
     永远不改变，拥抱过的美丽都再也不破碎
   </f-ellipsis>


### PR DESCRIPTION
去除第三方库的引用，改为原生