### PR TITLE
test(button): fix test case of 'on click'

### DIFF
--- a/packages/fighting-design/button/__test__/button.spec.ts
+++ b/packages/fighting-design/button/__test__/button.spec.ts
@@ -184,7 +184,7 @@ describe('FButton', () => {
       slots: { default: '点击测试' }
     })
     await wrapper.trigger('click')
-    expect(wrapper.emitted()).toBeDefined()
+    expect(wrapper.emitted('click')).toBeDefined()
   })
 
   test('disabled click', async () => {


### PR DESCRIPTION
- `wrapper.emitted()` always return `{}` whether trigger click or not.
- `toBeDefined` asserts that the value is not equal to `undefined`