### PR TITLE
fix(components): [tree] tree dom should be reactive

### DIFF
--- a/packages/fighting-design/tree/src/tree.vue
+++ b/packages/fighting-design/tree/src/tree.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
   import { Props, TREE_PROPS_KEY } from './props'
-  import { provide, toRef, reactive, ref } from 'vue'
+  import { provide, toRef, reactive, ref, computed } from 'vue'
   import FTreeItem from '../components/tree-item/index.vue'
   import { isArray, isObject } from '../../_utils'
   import { FCheckboxGroup } from '../../checkbox-group'
@@ -47,7 +47,7 @@
   }
 
   /** 处理后的树形结构 */
-  const tree: TreeItemModel[] = markTreeLevels(prop.data)
+  const tree = computed(() => markTreeLevels(prop.data))
 
   /** 多选列表 */
   const checkOption = ref([])


### PR DESCRIPTION
## Reproduction
Click a button and then push an object into `data`, but the DOM doesn't rerender.

```js
<script lang="ts" setup>
import { ref } from 'vue'

const data = ref([
  {
    label: 'Node 1',
    children: [
      {
        label: 'Node 1-1',
        children: [
          { label: 'Node 1-1-1' },
          { label: 'Node 1-1-2' },
          { label: 'Node 1-1-3' }
        ]
      },
      { label: 'Node 1-2' },
      { label: 'Node 1-3' }
    ]
  },
  {
    label: 'Node 2',
    children: [
      { label: 'Node 2-1' },
      { label: 'Node 2-2' },
      { label: 'Node 2-3', children: [{ label: 'Node 2-3-1' }] }
    ]
  },
  {
    label: 'Node 3'
  }
])

const handleClick = () => {
  data.value.push({
    label: 'Node 4'
  })
}
</script>

<template>
  <f-tree :data="data" />
  <FButton @click="handleClick">push</FButton>
</template>
```

## Solution

The code below located at `packages/fighting-design/tree/src/tree.vue`:

```js
const tree: TreeItemModel[] = markTreeLevels(prop.data)
```

Obviously, variable `tree` is not reactive.

So, we should wrapper it with a `computed`.

```js
const tree = computed(() => markTreeLevels(prop.data)
```

Then, it works.